### PR TITLE
Add mob target protection

### DIFF
--- a/src/main/java/net/lapismc/afkplus/AFKPlus.java
+++ b/src/main/java/net/lapismc/afkplus/AFKPlus.java
@@ -49,7 +49,7 @@ public final class AFKPlus extends LapisCorePlugin {
     @Override
     public void onEnable() {
         saveDefaultConfig();
-        registerConfiguration(new LapisCoreConfiguration(this, 10, 2));
+        registerConfiguration(new LapisCoreConfiguration(this, 11, 2));
         registerPermissions(new AFKPlusPermissions(this));
         registerLuckPermsContext();
         update();

--- a/src/main/java/net/lapismc/afkplus/AFKPlusListeners.java
+++ b/src/main/java/net/lapismc/afkplus/AFKPlusListeners.java
@@ -32,10 +32,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
-import org.bukkit.event.entity.CreatureSpawnEvent;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
-import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.event.entity.SpawnerSpawnEvent;
+import org.bukkit.event.entity.*;
 import org.bukkit.event.player.*;
 import org.bukkit.scheduler.BukkitTask;
 
@@ -249,6 +246,24 @@ public class AFKPlusListeners implements Listener {
         boolean shouldSpawn = spawnManager.shouldSpawnerSpawn(e.getSpawner());
         if (!shouldSpawn)
             e.setCancelled(false);
+    }
+
+    /*
+    Mob targeting protection
+     */
+    @EventHandler
+    public void onEntityTarget(EntityTargetLivingEntityEvent e) {
+       if (!plugin.getConfig().getBoolean("Protections.MobTargeting"))
+           return;
+        if (!(e.getEntity() instanceof Monster))
+            return;
+        if (!(e.getTarget() instanceof Player))
+            return;
+        Player player = ((Player) e.getTarget()).getPlayer();
+        if (player == null) return;
+        if (!plugin.getPlayer(player).isAFK())
+            return;
+        e.setCancelled(true);
     }
 
     /*

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-ConfigVersion: 10
+ConfigVersion: 11
 
 #Should the plugin auto download and install new versions when they are available
 UpdateDownload: true
@@ -73,6 +73,8 @@ Protections:
   #When enabled, mobs will not spawn if the AFK player is the cause of the spawning
   #This only applies to natural and spawner spawning
   MobSpawning: true
+  #When enabled AFK players will not be targeted by mobs
+  MobTargeting: false
 
 #Who should receive messages when players AFK status changes
 #Self = the player whose status has changed


### PR DESCRIPTION
When player is AFK and a mob comes nearby it will not target the player. I saw some rare cases where players died because of some random monster.

Side note: please add a license to the project