### PR TITLE
Allow 1.18+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     implementation 'org.ocpsoft.prettytime:prettytime:5.0.7.Final'
     compileOnly 'net.essentialsx:EssentialsX:2.20.1'
     compileOnly 'net.luckperms:api:5.4'
-    compileOnly 'org.spigotmc:spigot-api:1.20.4-R0.1-SNAPSHOT'
+    compileOnly 'org.spigotmc:spigot-api:1.18-R0.1-SNAPSHOT'
 }
 
 processResources {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: AFKPlus
 version: ${project.version}
 main: net.lapismc.afkplus.AFKPlus
-api-version: 1.19
+api-version: 1.18
 softdepend: [ PlaceholderAPI, Essentials, LuckPerms ]
 authors: [Dart2112]
 description: AFK for professional servers


### PR DESCRIPTION
No point in not supporting it, as no API used is exclusive to any versions higher
Should wait for LapisCore to update first (https://github.com/LapisPlugins/LapisCore/pull/11), but not required, as the plugin will still function with LapisCore being built on 1.20.2